### PR TITLE
Support Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "keywords": ["laravel", "etags", "etag", "middleware", "http"],
     "type": "library",
     "require": {
-        "illuminate/support": "^5.5|^6.0|^7.0|^8.0|^9.0",
-        "illuminate/http": "^5.5|^6.0|^7.0|^8.0|^9.0"
+        "illuminate/support": "^5.5|^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/http": "^5.5|^6.0|^7.0|^8.0|^9.0|^10.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.2",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "illuminate/http": "^5.5|^6.0|^7.0|^8.0|^9.0|^10.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.2",
+        "phpunit/phpunit": "^4.8|^5.2|^9.0",
         "squizlabs/php_codesniffer": "^2.8",
         "mockery/mockery": "^1.0",
         "php-coveralls/php-coveralls": "^2.1"

--- a/tests/EtagTest.php
+++ b/tests/EtagTest.php
@@ -5,11 +5,12 @@ namespace Tests;
 use Illuminate\Http\Request;
 use Matthewbdaly\ETagMiddleware\ETag;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
 /**
  * ETag test.
  */
-class EtagTest extends \PHPUnit_Framework_TestCase
+class EtagTest extends TestCase
 {
     /**
      * Test new request not cached.
@@ -20,13 +21,13 @@ class EtagTest extends \PHPUnit_Framework_TestCase
     {
         // Create mock header
         $headers = m::mock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
-        $headers->shouldReceive('get')->with('origin')->andReturn(['origin' => 'http://example.com']);
+        $headers->shouldReceive('get')->with('origin')->andReturn('http://example.com');
 
         // Create mock response
         $response = m::mock('Illuminate\Http\Response');
         $response->headers = $headers;
         $response->shouldReceive('getContent')->once()->andReturn('blah');
-        $response->shouldReceive('setEtag')->with(md5('{"origin":"http:\/\/example.com"}blah'));
+        $response->shouldReceive('setEtag')->with(md5('"http:\/\/example.com"blah'));
         $response->shouldNotReceive('setNotModified');
 
         // Create request
@@ -48,13 +49,13 @@ class EtagTest extends \PHPUnit_Framework_TestCase
     {
         // Create mock header
         $headers = m::mock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
-        $headers->shouldReceive('get')->with('origin')->andReturn(['origin' => 'http://example.com']);
+        $headers->shouldReceive('get')->with('origin')->andReturn('http://example.com');
 
         // Create mock response
         $response = m::mock('Illuminate\Http\Response');
         $response->headers = $headers;
         $response->shouldReceive('getContent')->once()->andReturn('blah');
-        $response->shouldReceive('setEtag')->with(md5('{"origin":"http:\/\/example.com"}blah'));
+        $response->shouldReceive('setEtag')->with(md5('"http:\/\/example.com"blah'));
         $response->shouldReceive('setNotModified')->once();
 
         // Create request
@@ -63,7 +64,7 @@ class EtagTest extends \PHPUnit_Framework_TestCase
         $request->shouldReceive('method')->andReturn('get');
         $request->shouldReceive('setMethod')->with('get')->andReturnTrue();
         $request->shouldReceive('getETags')->andReturn([
-            md5('{"origin":"http:\/\/example.com"}blah'),
+            md5('"http:\/\/example.com"blah'),
         ]);
 
         // Pass it to the middleware
@@ -102,7 +103,7 @@ class EtagTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/tests/EtagTest.php
+++ b/tests/EtagTest.php
@@ -38,6 +38,8 @@ class EtagTest extends TestCase
         $middlewareResponse = $middleware->handle($request, function () use ($response) {
             return $response;
         });
+
+        $this->assertSame($response, $middlewareResponse);
     }
 
     /**
@@ -72,6 +74,8 @@ class EtagTest extends TestCase
         $middlewareResponse = $middleware->handle($request, function () use ($response) {
             return $response;
         });
+
+        $this->assertSame($response, $middlewareResponse);
     }
 
     /**
@@ -96,6 +100,8 @@ class EtagTest extends TestCase
         $middlewareResponse = $middleware->handle($request, function () use ($response) {
             return $response;
         });
+
+        $this->assertSame($response, $middlewareResponse);
     }
 
     /**


### PR DESCRIPTION
## What this PR offers

* **Modify `require` in composer.json to support Laravel 10**
* Fix to pass the test with php version supported by Laravel10 (minimum 8.1)
  * Fix tests and dependencies to use phpunit 9 if possible
  * Fix tests to match Symfony 6 specs

## Supplement

I confirmed in my environment that all php versions after php-7.2 written in .travis.yml passed the test.