### PR TITLE
Use isNotModified method

### DIFF
--- a/src/ETag.php
+++ b/src/ETag.php
@@ -40,16 +40,11 @@ class ETag
         // Generate Etag
         $etag = md5(json_encode($response->headers->get('origin')) . (string)$response->getContent());
 
-        // Load the Etag sent by client
-        $requestEtag = str_replace('"', '', $request->getETags());
-
-        // Check to see if Etag has changed
-        if ($requestEtag && $requestEtag[0] == $etag) {
-            $response->setNotModified();
-        }
-
         // Set Etag
         $response->setEtag($etag);
+
+        // Check to see if Etag has changed. If not, send 304 and exit.
+        $response->isNotModified($request);
 
         // Set back to original method
         $request->setMethod($initialMethod); // set back to original method


### PR DESCRIPTION
I found this in the Symphony documentation: the official method for checking etags.
It takes the request as an argument, and checks if it contains etags headers, and if they match it returns 304 and exits with empty response.
It's a little to advanced from this implementation, and it supports other tags and weak etags.
https://github.com/symfony/symfony/blob/6637b78a4fcba7cef818f2a022e096d503690ac5/src/Symfony/Component/HttpFoundation/Response.php#L1159
What do you think about this approch?

The only breaking change is that with this the server returns an empty response instead of only updating the status code, when request is not modified.